### PR TITLE
Fix category titles

### DIFF
--- a/src/redux/directory/directory-reducer.js
+++ b/src/redux/directory/directory-reducer.js
@@ -20,19 +20,19 @@ sections : [
            linkUrl : 'shop/sneakers'
         },
         {
-           title: 'womens',
+           title: 'women',
            imageUrl: 'https://i.ibb.co/GCCdy8t/womens.png',
            size: 'large',
             id: 4,
-          linkUrl: 'shop/womens'
+          linkUrl: 'shop/women'
         },
          {
-            title: 'mens',
+            title: 'men',
             imageUrl: 'https://i.ibb.co/R70vBrQ/men.png',
            size: 'large',
             men : 'last',
             id: 5,
-            linkUrl: 'shop/mens'
+            linkUrl: 'shop/men'
   
         }
         ]


### PR DESCRIPTION
There's no such things as womens and mens in English. Women and men are already in plural form.

Ideally, it would be greate to rename the womens.png -> women.png but I don't have access to it. 

Hope you find this PR useful.

Great job btw! 👍 